### PR TITLE
security: fail closed when x402 verifier libs are unavailable

### DIFF
--- a/tests/test_manual_mode_fail_closed.py
+++ b/tests/test_manual_mode_fail_closed.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest import mock
+
+from flask import Flask, jsonify
+
+from openclaw_x402.middleware import X402Middleware
+import openclaw_x402.middleware as middleware_module
+
+
+def create_test_app():
+    app = Flask(__name__)
+    x402 = X402Middleware(app, treasury="0xdeadbeef")
+
+    @app.route("/premium")
+    @x402.premium(price="1000", description="Premium endpoint")
+    def premium_endpoint():
+        return jsonify({"ok": True})
+
+    @app.route("/free")
+    @x402.premium(price="0", description="Free endpoint")
+    def free_endpoint():
+        return jsonify({"ok": True})
+
+    return app
+
+
+class ManualModeFailClosedTests(unittest.TestCase):
+    def setUp(self):
+        app = create_test_app()
+        self.client = app.test_client()
+
+    @mock.patch.object(middleware_module, "X402_LIB_AVAILABLE", False)
+    def test_paid_route_without_header_returns_402(self):
+        response = self.client.get("/premium")
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(response.get_json()["error"], "Payment Required")
+
+    @mock.patch.object(middleware_module, "X402_LIB_AVAILABLE", False)
+    def test_paid_route_with_fake_header_still_returns_402(self):
+        response = self.client.get(
+            "/premium",
+            headers={"X-PAYMENT": "totally-fake-token"},
+        )
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(response.get_json()["error"], "Payment Required")
+
+    @mock.patch.object(middleware_module, "X402_LIB_AVAILABLE", False)
+    def test_free_route_remains_accessible_in_manual_mode(self):
+        response = self.client.get(
+            "/free",
+            headers={"X-PAYMENT": "totally-fake-token"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"ok": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes a payment-bypass path in `X402Middleware.premium()` when `x402` verification libs are unavailable.

Closes #1.

## Problem
In manual mode (`X402_LIB_AVAILABLE=false`), the middleware previously trusted any `X-PAYMENT` header and allowed access to paid routes without verification.

## Fix
- Remove the manual-trust pass-through path.
- Fail closed when verifier libs are unavailable, even if `X-PAYMENT` is present.
- Keep free routes (`price="0"`) unchanged.

## Tests
Added `tests/test_manual_mode_fail_closed.py` with regression coverage:
- paid route without header => `402`
- paid route with fake `X-PAYMENT` => `402`
- free route remains accessible => `200`

### Command
```bash
python3 -m unittest -q tests.test_manual_mode_fail_closed
```

### Output
```text
Rejected unverified X-PAYMENT header in manual mode for /premium
----------------------------------------------------------------------
Ran 3 tests in 0.023s

OK
```
