### PR TITLE
deps: add Dependabot for pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "dependabot"
+    ignore:
+      # Ignore patch updates to avoid breaking changes from Flask bugfix releases
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    # Groups pip updates for cleaner PRs
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      development-dependencies:
+        dependency-type: "development"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
## Summary

Added Dependabot configuration for automated pip dependency updates on the `openclaw-x402` Python project.

## What This Does

- **Ecosystem**: pip (Python packages via `pyproject.toml`)
- **Schedule**: Weekly checks every Monday at 09:00 UTC
- **Target**: All dependencies in the root `pyproject.toml`
- **Groups**: Separates production and development dependencies into focused PRs
- **Patch suppression**: Ignores semver-patch updates to avoid noisy changelog entries from Flask bugfix releases

## Changes

- Added `.github/dependabot.yml` with pip configuration

## Testing

- [x] File created and committed to `dependabot/config-XXXXXXXX` branch
- [x] Dependabot YAML schema validated (standard v2 format)

## Bounty Reference

- Closes `Scottcjn/rustchain-bounties#1613` (Set up Dependabot for any Elyan Labs repo)
- Reward: 3 RTC

## RTC Wallet

`RTC2fe3c33c77666ff76a1cd0999fd4466ee81250ff`

---

*Automated PR submitted via GitHub API by Jujujuda (Atlas bounty hunter)*
