### PR TITLE
security(x402): fail closed on payment verification (2 Critical bypasses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add to your MCP config (`~/.claude/claude_desktop_config.json` or project `.mcp.
       "env": {
         "RUSTCHAIN_NODE": "https://50.28.86.131",
         "TREASURY_WALLET": "your-wallet-id",
-        "X402_TESTNET": "1"
+        "X402_TESTNET": "0"
       }
     }
   }
@@ -120,7 +120,7 @@ When an agent pays for a tool, it includes a `payment_token` argument:
 }
 ```
 
-The server verifies this transaction exists on RustChain before executing the tool. In testnet mode (`X402_TESTNET=1`), verification is relaxed for development.
+The server verifies this transaction exists on RustChain (a successful on-chain lookup with matching treasury destination, sufficient amount, and a confirmed sender) before executing the tool. Verification is **always required** — `X402_TESTNET` only hints which node to use and never bypasses verification or accepts a payment on trust.
 
 ## Flask Middleware (REST APIs)
 
@@ -147,7 +147,7 @@ The Flask middleware uses USDC on Base chain via Coinbase facilitator. The MCP s
 |----------|---------|---------|
 | `RUSTCHAIN_NODE` | `https://50.28.86.131` | RustChain node URL |
 | `TREASURY_WALLET` | `openclaw-x402-treasury` | Wallet receiving payments |
-| `X402_TESTNET` | `1` | Accept payments on trust (dev mode) |
+| `X402_TESTNET` | `0` | Node hint only — does **not** bypass payment verification |
 | `RC_ADMIN_KEY` | | Admin key for verified transfers |
 
 ## Why x402 + MCP

--- a/openclaw_x402/mcp_server.py
+++ b/openclaw_x402/mcp_server.py
@@ -70,7 +70,8 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
 
     tx_id = token.get("tx_id", "")
     amount = float(token.get("amount", 0))
-    sender = token.get("from", "")
+    # NOTE: the client-supplied "from" is intentionally ignored; the verified
+    # sender is read from the on-chain tx below.
 
     if amount < expected_price:
         return {
@@ -87,21 +88,29 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
         )
         if resp.status_code == 200:
             tx_data = resp.json()
-            if (
-                tx_data.get("to") == TREASURY_WALLET
-                and float(tx_data.get("amount", 0)) >= expected_price
-            ):
-                return {"valid": True, "tx_id": tx_id, "from": sender, "amount": amount}
-            return {"valid": False, "error": "Transaction destination or amount mismatch."}
-        # Testnet fallback
-        if os.environ.get("X402_TESTNET", "1") == "1":
-            log.warning("Testnet mode: accepting payment on trust (tx_id=%s)", tx_id)
-            return {"valid": True, "tx_id": tx_id, "from": sender, "amount": amount, "mode": "testnet"}
+            chain_to = tx_data.get("to")
+            chain_from = tx_data.get("from")
+            chain_amount = float(tx_data.get("amount", 0))
+            if chain_to == TREASURY_WALLET and chain_amount >= expected_price and chain_from:
+                # Bind the result to the verified on-chain sender AND amount.
+                # Never echo the client-supplied `from`/`amount` (those are
+                # attacker-controlled and would corrupt downstream accounting).
+                return {
+                    "valid": True,
+                    "tx_id": tx_id,
+                    "from": chain_from,
+                    "amount": chain_amount,
+                }
+            return {
+                "valid": False,
+                "error": "Transaction destination, amount, or sender could not be verified.",
+            }
+        # SECURITY (fail closed): never accept a payment "on trust" when the
+        # ledger lookup does not return a verified 200. The previous testnet
+        # fallback (default ON) accepted any self-asserted token whenever the
+        # tx lookup 404'd/errored — i.e. for every fabricated tx_id.
         return {"valid": False, "error": f"Cannot verify tx: HTTP {resp.status_code}"}
     except Exception as e:
-        if os.environ.get("X402_TESTNET", "1") == "1":
-            log.warning("Testnet mode: accepting payment on trust (%s)", e)
-            return {"valid": True, "tx_id": tx_id, "from": sender, "amount": amount, "mode": "testnet"}
         return {"valid": False, "error": f"Verification failed: {e}"}
 
 
@@ -317,7 +326,9 @@ def main():
     log.info("Starting OpenClaw x402 MCP Server")
     log.info("  Node: %s", RUSTCHAIN_NODE)
     log.info("  Treasury: %s", TREASURY_WALLET)
-    log.info("  Testnet: %s", "ON" if os.environ.get("X402_TESTNET", "1") == "1" else "OFF")
+    # Payment verification always requires a real on-chain 200 lookup now;
+    # X402_TESTNET no longer bypasses verification. Default OFF.
+    log.info("  Testnet node hint: %s", "ON" if os.environ.get("X402_TESTNET", "0") == "1" else "OFF")
     mcp.run()
 
 

--- a/openclaw_x402/middleware.py
+++ b/openclaw_x402/middleware.py
@@ -127,31 +127,19 @@ class X402Middleware:
                 # Check for x402 payment header
                 payment_header = request.headers.get("X-PAYMENT", "").strip()
 
-                if payment_header and X402_LIB_AVAILABLE:
-                    # Verify via facilitator (real x402 flow)
-                    try:
-                        # The x402 Flask middleware handles verification
-                        self._log_payment(
-                            payer="x402-verified",
-                            endpoint=request.path,
-                            amount=price,
-                            tx_hash=payment_header[:66],
-                            description=description,
-                        )
-                        return f(*args, **kwargs)
-                    except Exception as e:
-                        log.error("x402 verification failed: %s", e)
-                        return self._payment_required(price, description)
-
-                if not X402_LIB_AVAILABLE:
-                    if payment_header:
-                        log.warning(
-                            "Rejected unverified X-PAYMENT header in manual mode for %s",
-                            request.path,
-                        )
-                    return self._payment_required(price, description)
-
-                # No payment — return 402
+                # SECURITY (fail closed): the facilitator verification path is
+                # not actually wired here — the imported x402 middleware is never
+                # invoked — so an X-PAYMENT header must NEVER be trusted on its
+                # own. Previously, with the x402 lib installed, ANY non-empty
+                # X-PAYMENT header was logged as "x402-verified" and granted free
+                # access. Until real on-chain/facilitator settlement verification
+                # is implemented, every unverified request gets a 402.
+                if payment_header:
+                    log.warning(
+                        "Rejected unverified X-PAYMENT header for %s "
+                        "(facilitator verification not implemented; failing closed)",
+                        request.path,
+                    )
                 return self._payment_required(price, description)
 
             return wrapper

--- a/tests/test_mcp_payment_helpers.py
+++ b/tests/test_mcp_payment_helpers.py
@@ -44,20 +44,24 @@ def test_verify_payment_accepts_matching_confirmed_ledger_transaction(monkeypatc
         assert url.endswith("/api/tx/tx-ok")
         assert verify is False
         assert timeout == 10
-        return DummyResponse(200, {"to": "openclaw-treasury", "amount": "0.25"})
+        # Ledger reports the real sender + amount; client claims differ below.
+        return DummyResponse(
+            200, {"to": "openclaw-treasury", "amount": "0.25", "from": "chain-sender"}
+        )
 
     monkeypatch.setattr(mcp_server.httpx, "get", fake_get)
 
     result = mcp_server._verify_payment(
-        json.dumps({"tx_id": "tx-ok", "from": "payer-wallet", "amount": 0.25}),
+        json.dumps({"tx_id": "tx-ok", "from": "client-claimed-wallet", "amount": 99.0}),
         0.25,
         "bcos_report",
     )
 
+    # Result must bind to the ON-CHAIN sender + amount, never the client's claims.
     assert result == {
         "valid": True,
         "tx_id": "tx-ok",
-        "from": "payer-wallet",
+        "from": "chain-sender",
         "amount": 0.25,
     }
 
@@ -78,8 +82,38 @@ def test_verify_payment_rejects_confirmed_transaction_to_wrong_treasury(monkeypa
 
     assert result == {
         "valid": False,
-        "error": "Transaction destination or amount mismatch.",
+        "error": "Transaction destination, amount, or sender could not be verified.",
     }
+
+
+def test_verify_payment_rejects_when_chain_sender_missing(monkeypatch):
+    # A confirmed tx to the right treasury but with no on-chain sender must NOT
+    # be trusted (prevents binding to a client-supplied 'from').
+    monkeypatch.setattr(mcp_server, "TREASURY_WALLET", "openclaw-treasury")
+    monkeypatch.setattr(
+        mcp_server.httpx,
+        "get",
+        lambda *a, **k: DummyResponse(200, {"to": "openclaw-treasury", "amount": "1.0"}),
+    )
+    result = mcp_server._verify_payment(
+        json.dumps({"tx_id": "tx-nofrom", "from": "client", "amount": 1.0}), 0.25, "bcos_report"
+    )
+    assert result["valid"] is False
+
+
+def test_verify_payment_fails_closed_on_network_exception(monkeypatch):
+    # Even with the legacy X402_TESTNET=1 set, a lookup error must NOT fail open.
+    monkeypatch.setenv("X402_TESTNET", "1")
+
+    def boom(*a, **k):
+        raise RuntimeError("node down")
+
+    monkeypatch.setattr(mcp_server.httpx, "get", boom)
+    result = mcp_server._verify_payment(
+        json.dumps({"tx_id": "any", "from": "client", "amount": 1.0}), 0.25, "bcos_report"
+    )
+    assert result["valid"] is False
+    assert "Verification failed" in result["error"]
 
 
 def test_verify_payment_reports_unverified_tx_when_testnet_fallback_disabled(monkeypatch):


### PR DESCRIPTION
## Two Critical payment bypasses (red-team confirmed, fail-closed fix)

**1. `middleware.premium()` fail-open paywall** — with the optional x402 lib installed, *any* non-empty `X-PAYMENT` header was logged as `x402-verified` and granted **free access** (no facilitator call, no signature, no on-chain check). Now fails closed: unverified headers always get 402.

**2. `mcp_server._verify_payment()` testnet bypass** — `X402_TESTNET` defaulted **ON** and the 404/exception paths returned `valid=True` on trust, so any **fabricated tx_id** (which naturally 404s) bypassed payment. Now: never fail open on a failed lookup; `X402_TESTNET` no longer bypasses verification (default OFF); result **binds to the on-chain sender + amount** (not client-supplied) and rejects when the chain sender is absent.

## Tests
**28 passed.** 2 existing tests tightened to assert the secure contract (chain-bound `from`/`amount`), 2 new tests (chain-sender-missing → reject; network exception → fail closed even with legacy `X402_TESTNET=1`). README updated.

## Tri-brain review (Codex 5.5 + Grok; GPT-OSS offline)
Codex: no bypasses/regressions; applied its 2 sender/amount-binding tightenings. Grok's "breaking change" notes are the *intended* security hardening + the now-fixed README.

## Follow-ups (not in this PR)
Consumed-tx replay table (UNIQUE `tx_id`); enable TLS verification once nodes have proper certs; wire real facilitator `/verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)