### PR TITLE
security(mcp): a paid tx can be replayed for unlimited calls

### DIFF
--- a/openclaw_x402/mcp_server.py
+++ b/openclaw_x402/mcp_server.py
@@ -33,6 +33,7 @@ import hashlib
 import json
 import logging
 import os
+import sqlite3
 import time
 
 import httpx
@@ -55,6 +56,53 @@ mcp = FastMCP(
 )
 
 # --- Payment verification ---
+
+# Spent-transaction ledger. A payment_token is a bearer credential: anyone
+# holding the tx_id (including any third party reading it off the public
+# ledger) can present it. One transaction must therefore buy exactly one call.
+SPENT_TX_DB = os.environ.get(
+    "X402_SPENT_TX_DB",
+    os.path.join(os.path.expanduser("~"), ".openclaw-x402", "spent_tx.db"),
+)
+
+
+def _consume_tx(tx_id: str, tool_name: str) -> str:
+    """
+    Atomically mark a verified tx_id as spent.
+
+    Returns "claimed" the first time a tx_id is seen, "replay" if it was
+    already spent, and "unavailable" if the ledger cannot be written --
+    which is refused rather than accepted, in line with the rest of the
+    verification path failing closed.
+    """
+    if not tx_id:
+        return "replay"
+    try:
+        parent = os.path.dirname(SPENT_TX_DB)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        conn = sqlite3.connect(SPENT_TX_DB, timeout=10)
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS spent_tx ("
+                "  tx_id TEXT PRIMARY KEY,"
+                "  tool TEXT,"
+                "  spent_at REAL"
+                ")"
+            )
+            conn.execute(
+                "INSERT INTO spent_tx (tx_id, tool, spent_at) VALUES (?, ?, ?)",
+                (tx_id, tool_name, time.time()),
+            )
+            conn.commit()
+            return "claimed"
+        except sqlite3.IntegrityError:
+            return "replay"
+        finally:
+            conn.close()
+    except Exception as e:
+        log.error("Spent-tx ledger unavailable (%s): refusing payment %s", e, tx_id)
+        return "unavailable"
 
 
 def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -> dict:
@@ -92,6 +140,22 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
             chain_from = tx_data.get("from")
             chain_amount = float(tx_data.get("amount", 0))
             if chain_to == TREASURY_WALLET and chain_amount >= expected_price and chain_from:
+                # A confirmed transaction stays confirmed forever, so it would
+                # otherwise pay for unlimited calls. Spend it exactly once.
+                claim = _consume_tx(tx_id, tool_name)
+                if claim == "replay":
+                    return {
+                        "valid": False,
+                        "error": (
+                            "Payment token already used. Each transaction pays "
+                            "for exactly one call -- send a new payment."
+                        ),
+                    }
+                if claim != "claimed":
+                    return {
+                        "valid": False,
+                        "error": "Cannot verify payment: spent-transaction ledger unavailable.",
+                    }
                 # Bind the result to the verified on-chain sender AND amount.
                 # Never echo the client-supplied `from`/`amount` (those are
                 # attacker-controlled and would corrupt downstream accounting).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import openclaw_x402.mcp_server as mcp_server
+
+
+@pytest.fixture(autouse=True)
+def isolated_spent_tx_ledger(tmp_path, monkeypatch):
+    """Give every test its own spent-transaction ledger.
+
+    Without this the ledger would live in the developer's home directory and
+    leak between tests and between runs (a tx_id spent by one test would be
+    rejected as a replay by the next one).
+    """
+    monkeypatch.setattr(mcp_server, "SPENT_TX_DB", str(tmp_path / "spent_tx.db"))

--- a/tests/test_mcp_payment_replay.py
+++ b/tests/test_mcp_payment_replay.py
@@ -1,0 +1,79 @@
+import json
+
+import openclaw_x402.mcp_server as mcp_server
+
+
+class DummyResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def _confirmed_tx(monkeypatch, amount="0.25"):
+    """Make the ledger report one confirmed payment to the treasury."""
+    monkeypatch.setattr(mcp_server, "TREASURY_WALLET", "openclaw-treasury")
+    monkeypatch.setattr(
+        mcp_server.httpx,
+        "get",
+        lambda *a, **k: DummyResponse(
+            200, {"to": "openclaw-treasury", "amount": amount, "from": "chain-sender"}
+        ),
+    )
+
+
+def _token(tx_id="tx-paid", amount=0.25):
+    return json.dumps({"tx_id": tx_id, "from": "payer", "amount": amount})
+
+
+def test_payment_token_is_spent_after_first_use(monkeypatch):
+    """A confirmed tx stays confirmed forever; it must still buy only one call."""
+    _confirmed_tx(monkeypatch)
+
+    first = mcp_server._verify_payment(_token(), 0.25, "bcos_report")
+    assert first["valid"] is True
+
+    second = mcp_server._verify_payment(_token(), 0.25, "bcos_report")
+    assert second["valid"] is False
+    assert "already used" in second["error"]
+
+
+def test_spent_token_cannot_be_carried_to_another_tool(monkeypatch):
+    _confirmed_tx(monkeypatch)
+
+    assert mcp_server._verify_payment(_token(), 0.25, "bcos_report")["valid"] is True
+
+    reused = mcp_server._verify_payment(_token(), 0.1, "premium_search")
+    assert reused["valid"] is False
+    assert "already used" in reused["error"]
+
+
+def test_gate_refuses_the_second_call_with_the_same_token(monkeypatch):
+    _confirmed_tx(monkeypatch)
+
+    assert mcp_server._gate(_token(), 0.25, "bcos_report", "BCOS trust report") is None
+
+    replay = mcp_server._gate(_token(), 0.25, "bcos_report", "BCOS trust report")
+    assert replay is not None
+    assert json.loads(replay)["status"] == "payment_failed"
+
+
+def test_a_different_transaction_still_pays(monkeypatch):
+    _confirmed_tx(monkeypatch)
+
+    assert mcp_server._verify_payment(_token("tx-a"), 0.25, "bcos_report")["valid"] is True
+    assert mcp_server._verify_payment(_token("tx-b"), 0.25, "bcos_report")["valid"] is True
+
+
+def test_unwritable_ledger_fails_closed(monkeypatch, tmp_path):
+    """If the spend ledger cannot be written, refuse rather than allow replays."""
+    _confirmed_tx(monkeypatch)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    monkeypatch.setattr(mcp_server, "SPENT_TX_DB", str(blocker / "spent_tx.db"))
+
+    result = mcp_server._verify_payment(_token(), 0.25, "bcos_report")
+    assert result["valid"] is False
+    assert "ledger unavailable" in result["error"]


### PR DESCRIPTION
## The bug

`_verify_payment()` checks that the tx exists on the RustChain ledger, pays the treasury and covers the price — but nothing ever records that the token was used. A confirmed transaction stays confirmed forever, so the same `payment_token` keeps verifying:

```python
token = '{"tx_id": "<one real 0.25 RTC payment>", "from": "me", "amount": 0.25}'
bcos_report(repo="a", payment_token=token)   # paid
bcos_report(repo="b", payment_token=token)   # free
bcos_report(repo="c", payment_token=token)   # free ... forever
premium_search(query="x", payment_token=token)  # also free (0.1 <= 0.25)
```

One payment buys unlimited calls, across every tool priced at or below the amount paid. Worse, a `payment_token` is a bearer credential made of public ledger data: the gate only asks "does this tx exist and did it pay the treasury", never "is this caller the payer, and is this the call it paid for". Anyone who reads a treasury-bound tx id off the chain can call the paid tools without paying anything.

That undercuts the whole premise in the README — *"Agents that pay 0.1 RTC get the data"* — since the seller is paid once per token, not once per call.

## The fix

Spend the token. After the on-chain check passes, the verified `tx_id` is inserted into a small sqlite ledger with a `PRIMARY KEY`, so the second presentation loses the race and is refused:

```
{"valid": false, "error": "Payment token already used. Each transaction pays for exactly one call -- send a new payment."}
```

The insert is what makes the decision, so two concurrent calls with the same token cannot both win. Ledger path is `X402_SPENT_TX_DB` (default `~/.openclaw-x402/spent_tx.db`). If it can't be written, the payment is refused rather than accepted — the same fail-closed posture as #2 and #12, since failing open here means unlimited replays.

Distinct payments are unaffected: a second, different tx verifies normally (covered by a test).

## Tests

New `tests/test_mcp_payment_replay.py` (pytest + stdlib, no network — `httpx.get` is stubbed): token spent after first use, spent token can't be carried to a cheaper tool, `_gate` refuses the replay, a different tx still pays, unwritable ledger fails closed.

Also adds `tests/conftest.py` with an autouse fixture giving each test its own ledger. Without it the ledger would be created in the developer's home directory and leak between runs — I hit exactly that: the suite passed once and then `test_verify_payment_accepts_matching_confirmed_ledger_transaction` failed on the second run because `tx-ok` was already spent. With the fixture the suite is idempotent (ran it twice: `33 passed` both times, nothing written outside tmp).

Mutation check: removing just the `_consume_tx()` call from `_verify_payment` makes 4 of the 5 new tests fail (the "different transaction still pays" control keeps passing), so they are not vacuous.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
