### PR TITLE
feat(casper): add Casper/wCSPR as a third payment rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,99 @@ def premium_data():
     return jsonify({"data": "your premium content"})
 ```
 
-The Flask middleware uses USDC on Base chain via Coinbase facilitator. The MCP server uses RTC on RustChain. Same pattern, two payment rails.
+The Flask middleware uses USDC on Base chain via Coinbase facilitator. The MCP server uses RTC on RustChain. Same pattern, three payment rails (see Casper below).
+
+## x402 on Casper
+
+The Flask middleware also speaks x402 on [Casper](https://casper.network). Settlement happens in wCSPR
+exposed as a CEP-18 token, brokered by an x402 v2 facilitator that pays the gas for the on-chain
+`transfer_with_authorization` deploy. Same decorator, different rail:
+
+```python
+from flask import Flask, jsonify
+from openclaw_x402 import X402Middleware
+
+app = Flask(__name__)
+x402 = X402Middleware(
+    app,
+    rail="casper",
+    treasury="00" + "ab" * 32,  # your Casper account hash
+)
+
+@app.route("/api/premium/data")
+@x402.premium(price="7500000000", description="Premium data export")  # 7.5 CSPR
+def premium_data():
+    return jsonify({"data": "your premium content"})
+```
+
+**Prices are in motes**, the atomic unit of CSPR — 9 decimals, `1 CSPR = 1_000_000_000 motes`.
+Helpers are exported so you never have to count zeros:
+
+```python
+from openclaw_x402 import cspr_to_motes, motes_to_cspr
+
+cspr_to_motes("7.5")        # "7500000000"
+motes_to_cspr("7500000000") # "7.5"
+```
+
+### Payment flow
+
+```
+Agent GETs the route
+    |
+    v
+No X-PAYMENT header? ---> 402 + accepts[] (scheme "exact", network, payTo, amount, asset)
+    |                          |
+    |                     Agent signs a TransferWithAuthorization payload
+    |                          |
+    |                     Agent retries with X-PAYMENT: base64(json)
+    |
+Has X-PAYMENT header
+    |
+    v
+POST /verify to facilitator ---> not valid? 402 + reason
+    |
+    v
+POST /settle to facilitator ---> failed? 402 + reason
+    |
+    v
+Run the route, return 200 + X-PAYMENT-RESPONSE (base64 settlement receipt)
+```
+
+Verification **fails closed**, exactly like the other rails: a malformed header, a rejected payload,
+a failed settlement, or an unreachable facilitator all produce a fresh 402. Payload shape is
+pre-checked locally (`payTo`, amount, network, required authorization fields) before anything goes
+over the wire, so obviously bad requests never cost a facilitator round-trip.
+
+### Networks
+
+| CAIP-2 id | Chain |
+|-----------|-------|
+| `casper:casper` | Casper mainnet (default) |
+| `casper:casper-test` | Casper testnet |
+
+### Configuration
+
+Everything is configurable, with the public cspr.cloud facilitator as the default:
+
+```python
+from openclaw_x402 import CasperRailConfig, X402Middleware
+
+x402 = X402Middleware(
+    app,
+    rail="casper",
+    casper_config=CasperRailConfig(
+        treasury="00" + "ab" * 32,
+        network="casper:casper-test",
+        facilitator_url="https://x402-facilitator.cspr.cloud",
+        asset="<64-hex CEP-18 package hash>",   # wCSPR
+        token_name="wCSPR",
+        token_version="1",
+    ),
+)
+```
+
+`GET /api/x402/status` reports the active rail and its Casper settings.
 
 ## Environment Variables
 
@@ -161,6 +253,13 @@ The Flask middleware uses USDC on Base chain via Coinbase facilitator. The MCP s
 | `TREASURY_WALLET` | `openclaw-x402-treasury` | Wallet receiving payments |
 | `X402_TESTNET` | `0` | Node hint only — does **not** bypass payment verification |
 | `RC_ADMIN_KEY` | | Admin key for verified transfers |
+| `CASPER_NETWORK` | `casper:casper` | Casper CAIP-2 network (`casper:casper-test` for testnet) |
+| `CASPER_FACILITATOR_URL` | `https://x402-facilitator.cspr.cloud` | x402 v2 facilitator for Casper |
+| `CASPER_TREASURY` | | Casper account hash receiving payments |
+| `CASPER_WCSPR_PACKAGE_HASH` | | CEP-18 contract package hash of the wCSPR settlement token |
+| `CASPER_TOKEN_NAME` | `wCSPR` | CEP-18 token name (seeds the EIP-712 domain) |
+| `CASPER_TOKEN_VERSION` | `1` | CEP-18 token version (seeds the EIP-712 domain) |
+| `CASPER_MAX_TIMEOUT_SECONDS` | `900` | Validity window advertised in the 402 challenge |
 
 ## Why x402 + MCP
 
@@ -175,6 +274,7 @@ This is the infrastructure layer for agent commerce. Every GPU cluster, every AP
 - [RustChain](https://rustchain.org) -- Proof-of-Antiquity blockchain
 - [FastMCP](https://gofastmcp.com) -- Python MCP framework
 - [Coinbase x402](https://docs.cdp.coinbase.com/x402/docs/welcome) -- x402 on Base chain
+- [Casper](https://casper.network) -- x402 on Casper, wCSPR settlement ([cspr.cloud docs](https://docs.cspr.cloud))
 
 ## License
 

--- a/examples/casper_flask_app.py
+++ b/examples/casper_flask_app.py
@@ -1,0 +1,52 @@
+"""
+Minimal Flask app metered in wCSPR on Casper via x402.
+
+Run:
+    pip install -e ".[flask]"
+    export CASPER_TREASURY=00<your 64-hex account hash>
+    export CASPER_WCSPR_PACKAGE_HASH=<64-hex CEP-18 package hash>
+    python examples/casper_flask_app.py
+
+Then:
+    curl -i http://localhost:5000/api/premium/weather
+    # -> 402 with an accepts[] block describing the Casper payment
+"""
+
+import os
+
+from flask import Flask, jsonify
+
+from openclaw_x402 import CasperRailConfig, X402Middleware, cspr_to_motes
+
+app = Flask(__name__)
+
+x402 = X402Middleware(
+    app,
+    rail="casper",
+    casper_config=CasperRailConfig(
+        treasury=os.environ.get("CASPER_TREASURY", "00" + "ab" * 32),
+        network=os.environ.get("CASPER_NETWORK", "casper:casper-test"),
+        asset=os.environ.get("CASPER_WCSPR_PACKAGE_HASH", "ef" * 32),
+    ),
+)
+
+# Prices are motes (9 decimals). 7.5 CSPR == "7500000000".
+PRICE = cspr_to_motes("7.5")
+
+
+@app.route("/api/premium/weather")
+@x402.premium(price=PRICE, description="Premium weather export")
+def premium_weather():
+    """Paid endpoint -- unlocked once the facilitator settles the payment."""
+    return jsonify({"city": "San Francisco", "weather": "foggy", "temperature": 60})
+
+
+@app.route("/api/free/health")
+@x402.premium(price="0", description="Health check")
+def health():
+    """Free endpoint -- $0 pricing passes straight through."""
+    return jsonify({"status": "ok"})
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/openclaw_x402/__init__.py
+++ b/openclaw_x402/__init__.py
@@ -11,18 +11,35 @@ Usage:
     @x402.premium(price="10000", description="Premium data export")
     def premium_data():
         return jsonify({"data": "..."})
+
+Casper rail (wCSPR CEP-18, amounts in motes at 9 decimals):
+    x402 = X402Middleware(app, rail="casper", treasury="00" + "ab" * 32)
 """
 
 __version__ = "0.2.0"
 
 from .middleware import X402Middleware
+from .casper import (
+    CasperPaymentError, CasperRail, CasperRailConfig,
+    cspr_to_motes, motes_to_cspr,
+    is_valid_account_hash, is_valid_package_hash,
+)
 from .config import (
     X402_NETWORK, USDC_BASE, WRTC_BASE, AERODROME_POOL,
     FACILITATOR_URL, SWAP_INFO, is_free, has_cdp_credentials,
+    CASPER_MAINNET, CASPER_TESTNET, CASPER_NETWORKS, CASPER_NETWORK,
+    CASPER_FACILITATOR_URL, CASPER_ASSET_DECIMALS, MOTES_PER_CSPR,
+    is_casper_network, casper_chain_name,
 )
 
 __all__ = [
     "X402Middleware",
     "X402_NETWORK", "USDC_BASE", "WRTC_BASE", "AERODROME_POOL",
     "FACILITATOR_URL", "SWAP_INFO", "is_free", "has_cdp_credentials",
+    "CasperPaymentError", "CasperRail", "CasperRailConfig",
+    "cspr_to_motes", "motes_to_cspr",
+    "is_valid_account_hash", "is_valid_package_hash",
+    "CASPER_MAINNET", "CASPER_TESTNET", "CASPER_NETWORKS", "CASPER_NETWORK",
+    "CASPER_FACILITATOR_URL", "CASPER_ASSET_DECIMALS", "MOTES_PER_CSPR",
+    "is_casper_network", "casper_chain_name",
 ]

--- a/openclaw_x402/casper.py
+++ b/openclaw_x402/casper.py
@@ -1,0 +1,409 @@
+"""
+Casper payment rail for OpenClaw x402.
+
+Third payment rail alongside USDC-on-Base (Flask middleware) and RTC-on-RustChain
+(MCP server). Settlement happens in a CEP-18 token (wCSPR by default) on the
+Casper network, brokered by an x402 v2 facilitator that exposes ``POST /verify``
+and ``POST /settle``.
+
+Amounts are always handled as **motes** -- the atomic unit of CSPR, 9 decimals::
+
+    1 CSPR = 1_000_000_000 motes
+
+Everything network-facing is configurable through :class:`CasperRailConfig`
+(or the matching environment variables in ``openclaw_x402.config``), with the
+public cspr.cloud facilitator as the default.
+
+Usage::
+
+    from openclaw_x402 import X402Middleware
+
+    app = Flask(__name__)
+    x402 = X402Middleware(
+        app,
+        rail="casper",
+        treasury="00" + "ab" * 32,           # Casper account hash
+    )
+
+    @app.route("/api/premium/data")
+    @x402.premium(price="7500000000", description="Premium data export")  # 7.5 CSPR
+    def premium_data():
+        return jsonify({"data": "..."})
+"""
+
+import base64
+import binascii
+import json
+import logging
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+from .config import (
+    CASPER_ASSET_DECIMALS,
+    CASPER_FACILITATOR_URL,
+    CASPER_MAX_TIMEOUT_SECONDS,
+    CASPER_NETWORK,
+    CASPER_NETWORKS,
+    CASPER_SCHEME,
+    CASPER_TOKEN_NAME,
+    CASPER_TOKEN_VERSION,
+    CASPER_TREASURY,
+    CASPER_WCSPR_PACKAGE_HASH,
+    MOTES_PER_CSPR,
+    X402_VERSION,
+)
+
+log = logging.getLogger("openclaw_x402.casper")
+
+_ACCOUNT_HASH_RE = re.compile(r"^(00|01)[0-9a-fA-F]{64}$")
+_PACKAGE_HASH_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+class CasperPaymentError(Exception):
+    """Raised when a Casper payment cannot be verified or settled."""
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        super().__init__(message or reason)
+        self.reason = reason
+        self.message = message or reason
+
+
+def is_valid_account_hash(value: str) -> bool:
+    """Return True if ``value`` is a Casper account hash (``00``/``01`` + 64 hex)."""
+    return bool(value) and bool(_ACCOUNT_HASH_RE.match(value))
+
+
+def is_valid_package_hash(value: str) -> bool:
+    """Return True if ``value`` is a 64-char hex CEP-18 contract package hash."""
+    return bool(value) and bool(_PACKAGE_HASH_RE.match(value))
+
+
+def cspr_to_motes(amount: Any) -> str:
+    """
+    Convert a CSPR amount to a motes string (9 decimals, no exponent).
+
+    ``cspr_to_motes("7.5") == "7500000000"``
+
+    Raises:
+        ValueError: if the amount is not a finite number or has sub-mote precision.
+    """
+    try:
+        value = Decimal(str(amount))
+    except (InvalidOperation, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid CSPR amount: {amount!r}") from exc
+    if not value.is_finite() or value < 0:
+        raise ValueError(f"Invalid CSPR amount: {amount!r}")
+    motes = value * MOTES_PER_CSPR
+    if motes != motes.to_integral_value():
+        raise ValueError(f"CSPR amount {amount!r} is finer than one mote")
+    return str(int(motes))
+
+
+def motes_to_cspr(motes: Any) -> str:
+    """
+    Convert a motes amount to a human-readable CSPR string.
+
+    ``motes_to_cspr("7500000000") == "7.5"``
+    """
+    try:
+        value = Decimal(str(motes))
+    except (InvalidOperation, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid mote amount: {motes!r}") from exc
+    if value != value.to_integral_value():
+        raise ValueError(f"Mote amounts must be whole numbers, got {motes!r}")
+    cspr = (value / MOTES_PER_CSPR).normalize()
+    return format(cspr, "f")
+
+
+class CasperRailConfig:
+    """
+    Configuration for the Casper payment rail.
+
+    Args:
+        treasury: Casper account hash receiving payments (``00`` + 64 hex).
+        network: CAIP-2 network id, ``casper:casper`` or ``casper:casper-test``.
+        facilitator_url: Base URL of an x402 v2 facilitator for Casper.
+        asset: CEP-18 contract package hash of the settlement token (wCSPR).
+        asset_decimals: Decimals of the settlement token (wCSPR uses 9).
+        token_name: CEP-18 token name seeding the EIP-712 domain.
+        token_version: CEP-18 token version seeding the EIP-712 domain.
+        max_timeout_seconds: Validity window advertised in the 402 challenge.
+        timeout: HTTP timeout (seconds) for facilitator calls.
+    """
+
+    def __init__(
+        self,
+        treasury: str = "",
+        network: str = CASPER_NETWORK,
+        facilitator_url: str = CASPER_FACILITATOR_URL,
+        asset: str = CASPER_WCSPR_PACKAGE_HASH,
+        asset_decimals: int = CASPER_ASSET_DECIMALS,
+        token_name: str = CASPER_TOKEN_NAME,
+        token_version: str = CASPER_TOKEN_VERSION,
+        max_timeout_seconds: int = CASPER_MAX_TIMEOUT_SECONDS,
+        timeout: float = 10.0,
+    ) -> None:
+        if network not in CASPER_NETWORKS:
+            raise ValueError(
+                f"Unsupported Casper network {network!r}. "
+                f"Expected one of {sorted(CASPER_NETWORKS)}."
+            )
+        self.treasury = treasury or CASPER_TREASURY
+        self.network = network
+        self.facilitator_url = facilitator_url.rstrip("/")
+        self.asset = asset
+        self.asset_decimals = int(asset_decimals)
+        self.token_name = token_name
+        self.token_version = token_version
+        self.max_timeout_seconds = int(max_timeout_seconds)
+        self.timeout = timeout
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the rail config for the ``/api/x402/status`` endpoint."""
+        return {
+            "rail": "casper",
+            "network": self.network,
+            "facilitator": self.facilitator_url,
+            "asset": self.asset,
+            "asset_decimals": self.asset_decimals,
+            "treasury": self.treasury,
+            "scheme": CASPER_SCHEME,
+            "motes_per_cspr": int(MOTES_PER_CSPR),
+        }
+
+
+class CasperRail:
+    """
+    Casper rail: builds 402 challenges and talks to the x402 facilitator.
+
+    The rail is deliberately stateless -- it owns no keys and never signs. The
+    payer signs the ``TransferWithAuthorization`` payload client-side and the
+    facilitator pays gas to submit the CEP-18 ``transfer_with_authorization``
+    deploy on settlement.
+    """
+
+    def __init__(self, config: Optional[CasperRailConfig] = None) -> None:
+        self.config = config or CasperRailConfig()
+
+    # --- 402 challenge ---------------------------------------------------
+
+    def payment_requirements(
+        self,
+        price: str,
+        description: str,
+        resource: str,
+    ) -> Dict[str, Any]:
+        """
+        Build an x402 v2 ``PaymentRequirements`` object for this rail.
+
+        Args:
+            price: Amount in motes (9 decimals) as a decimal string.
+            description: Human-readable endpoint description.
+            resource: Absolute URL of the protected resource.
+        """
+        return {
+            "scheme": CASPER_SCHEME,
+            "network": self.config.network,
+            "payTo": self.config.treasury,
+            "amount": str(price),
+            "maxAmountRequired": str(price),
+            "asset": self.config.asset,
+            "resource": resource,
+            "description": description,
+            "mimeType": "application/json",
+            "maxTimeoutSeconds": self.config.max_timeout_seconds,
+            "extra": {
+                "name": self.config.token_name,
+                "version": self.config.token_version,
+                "decimals": str(self.config.asset_decimals),
+            },
+        }
+
+    def challenge(self, price: str, description: str, resource: str) -> Dict[str, Any]:
+        """Build the full 402 response body (``accepts`` list, x402 v2 shape)."""
+        return {
+            "x402Version": X402_VERSION,
+            "error": "Payment Required",
+            "accepts": [self.payment_requirements(price, description, resource)],
+        }
+
+    # --- payload handling ------------------------------------------------
+
+    @staticmethod
+    def decode_payment_header(header: str) -> Dict[str, Any]:
+        """
+        Decode an ``X-PAYMENT`` header into an x402 ``PaymentPayload`` dict.
+
+        The header is base64-encoded JSON per the x402 spec; raw JSON is also
+        accepted for easier local testing.
+
+        Raises:
+            CasperPaymentError: with reason ``malformed_payload``.
+        """
+        raw = (header or "").strip()
+        if not raw:
+            raise CasperPaymentError("malformed_payload", "Empty X-PAYMENT header")
+        try:
+            decoded = base64.b64decode(raw, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError, ValueError):
+            decoded = raw
+        try:
+            payload = json.loads(decoded)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise CasperPaymentError(
+                "malformed_payload", "X-PAYMENT is not valid base64 JSON"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise CasperPaymentError(
+                "malformed_payload", "X-PAYMENT must decode to a JSON object"
+            )
+        return payload
+
+    def _check_payload_shape(
+        self, payload: Dict[str, Any], requirements: Dict[str, Any]
+    ) -> None:
+        """Cheap local pre-checks so obviously bad payloads never reach the wire."""
+        if payload.get("scheme", CASPER_SCHEME) != CASPER_SCHEME:
+            raise CasperPaymentError(
+                "unsupported_scheme", f"Expected scheme {CASPER_SCHEME!r}"
+            )
+        if payload.get("network") and payload["network"] != requirements["network"]:
+            raise CasperPaymentError(
+                "network_mismatch",
+                f"Payload network {payload['network']!r} != {requirements['network']!r}",
+            )
+        inner = payload.get("payload")
+        if not isinstance(inner, dict):
+            raise CasperPaymentError("malformed_payload", "Missing payload object")
+        authorization = inner.get("authorization")
+        if not isinstance(authorization, dict):
+            raise CasperPaymentError("malformed_payload", "Missing authorization object")
+        for field in ("from", "to", "value", "validAfter", "validBefore", "nonce"):
+            if not authorization.get(field):
+                raise CasperPaymentError(
+                    "malformed_payload", f"Missing authorization field {field!r}"
+                )
+        if not is_valid_account_hash(authorization["to"]):
+            raise CasperPaymentError(
+                "invalid_pay_to", "authorization.to is not a Casper account hash"
+            )
+        if authorization["to"] != requirements["payTo"]:
+            raise CasperPaymentError(
+                "pay_to_mismatch", "authorization.to does not match payTo"
+            )
+        if str(authorization["value"]) != str(requirements["amount"]):
+            raise CasperPaymentError(
+                "amount_mismatch",
+                f"Expected {requirements['amount']} motes, got {authorization['value']}",
+            )
+
+    # --- facilitator calls -----------------------------------------------
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.config.facilitator_url}{path}"
+        try:
+            response = httpx.post(url, json=body, timeout=self.config.timeout)
+        except Exception as exc:  # network error -> fail closed
+            raise CasperPaymentError(
+                "facilitator_unreachable", f"Facilitator {url} unreachable: {exc}"
+            ) from exc
+        if response.status_code != 200:
+            raise CasperPaymentError(
+                "facilitator_error",
+                f"Facilitator {url} returned HTTP {response.status_code}",
+            )
+        try:
+            data = response.json()
+        except Exception as exc:
+            raise CasperPaymentError(
+                "facilitator_error", f"Facilitator {url} returned non-JSON body"
+            ) from exc
+        if not isinstance(data, dict):
+            raise CasperPaymentError(
+                "facilitator_error", f"Facilitator {url} returned non-object body"
+            )
+        return data
+
+    def verify(
+        self, payload: Dict[str, Any], requirements: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Verify a payment payload with the facilitator (``POST /verify``).
+
+        Returns the facilitator response dict on success.
+
+        Raises:
+            CasperPaymentError: if the payload is malformed or rejected.
+        """
+        self._check_payload_shape(payload, requirements)
+        body = {
+            "x402Version": X402_VERSION,
+            "paymentPayload": self._normalized_payload(payload),
+            "paymentRequirements": requirements,
+        }
+        data = self._post("/verify", body)
+        if not data.get("isValid"):
+            raise CasperPaymentError(
+                data.get("invalidReason", "invalid_payment"),
+                data.get("invalidMessage", "Facilitator rejected the payment"),
+            )
+        return data
+
+    def settle(
+        self, payload: Dict[str, Any], requirements: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Settle a verified payment on-chain (``POST /settle``).
+
+        Returns the facilitator response dict on success (contains
+        ``transaction`` -- the Casper deploy hash -- and ``payer``).
+
+        Raises:
+            CasperPaymentError: if settlement fails for any reason.
+        """
+        body = {
+            "x402Version": X402_VERSION,
+            "paymentPayload": self._normalized_payload(payload),
+            "paymentRequirements": requirements,
+        }
+        data = self._post("/settle", body)
+        if not data.get("success"):
+            raise CasperPaymentError(
+                data.get("errorReason", "settlement_failed"),
+                data.get("errorMessage", "Facilitator could not settle the payment"),
+            )
+        return data
+
+    def verify_and_settle(
+        self, payment_header: str, requirements: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Full happy path: decode header, verify, then settle.
+
+        Returns:
+            ``(payload, settle_response)``
+
+        Raises:
+            CasperPaymentError: on any failure -- callers must fail closed.
+        """
+        payload = self.decode_payment_header(payment_header)
+        self.verify(payload, requirements)
+        return payload, self.settle(payload, requirements)
+
+    def _normalized_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill in x402 envelope defaults the client may have omitted."""
+        normalized = dict(payload)
+        normalized.setdefault("x402Version", X402_VERSION)
+        normalized.setdefault("scheme", CASPER_SCHEME)
+        normalized.setdefault("network", self.config.network)
+        return normalized
+
+    @staticmethod
+    def settlement_receipt(settle_response: Dict[str, Any]) -> str:
+        """Base64-encode a settle response for the ``X-PAYMENT-RESPONSE`` header."""
+        return base64.b64encode(
+            json.dumps(settle_response, separators=(",", ":")).encode("utf-8")
+        ).decode("ascii")

--- a/openclaw_x402/config.py
+++ b/openclaw_x402/config.py
@@ -6,8 +6,10 @@ Prices are in USDC atomic units (6 decimals): 1 USDC = 1,000,000.
 """
 
 import os
+from decimal import Decimal
 
 # --- x402 Constants ---
+X402_VERSION = 2  # x402 protocol version used by the Casper rail
 X402_NETWORK = "eip155:8453"  # Base mainnet (CAIP-2)
 USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"  # Native USDC on Base
 WRTC_BASE = "0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6"  # wRTC on Base
@@ -39,3 +41,40 @@ def is_free(price_str):
 def has_cdp_credentials():
     """Check if CDP API credentials are configured."""
     return bool(CDP_API_KEY_NAME and CDP_API_KEY_PRIVATE_KEY)
+
+
+# --- Casper rail (third payment rail) ---
+#
+# Settlement asset is wCSPR exposed as a CEP-18 token. CSPR amounts are always
+# expressed in motes, the atomic unit: 1 CSPR = 1_000_000_000 motes (9 decimals).
+
+CASPER_MAINNET = "casper:casper"
+CASPER_TESTNET = "casper:casper-test"
+CASPER_NETWORKS = (CASPER_MAINNET, CASPER_TESTNET)
+
+CASPER_SCHEME = "exact"
+CASPER_ASSET_DECIMALS = 9
+MOTES_PER_CSPR = Decimal(10) ** CASPER_ASSET_DECIMALS  # 1_000_000_000
+
+CASPER_NETWORK = os.environ.get("CASPER_NETWORK", CASPER_MAINNET)
+CASPER_FACILITATOR_URL = os.environ.get(
+    "CASPER_FACILITATOR_URL", "https://x402-facilitator.cspr.cloud"
+)
+CASPER_WCSPR_PACKAGE_HASH = os.environ.get("CASPER_WCSPR_PACKAGE_HASH", "")
+CASPER_TREASURY = os.environ.get("CASPER_TREASURY", "")
+CASPER_TOKEN_NAME = os.environ.get("CASPER_TOKEN_NAME", "wCSPR")
+CASPER_TOKEN_VERSION = os.environ.get("CASPER_TOKEN_VERSION", "1")
+CASPER_MAX_TIMEOUT_SECONDS = int(os.environ.get("CASPER_MAX_TIMEOUT_SECONDS", "900"))
+
+
+def is_casper_network(network):
+    """Check if a CAIP-2 network id is a supported Casper network."""
+    return network in CASPER_NETWORKS
+
+
+def casper_chain_name(network):
+    """Return the Casper chain name (``casper``/``casper-test``) for a CAIP-2 id."""
+    if not is_casper_network(network):
+        raise ValueError(f"Unsupported Casper network: {network!r}")
+    return network.split(":", 1)[1]
+

--- a/openclaw_x402/config.py
+++ b/openclaw_x402/config.py
@@ -77,4 +77,3 @@ def casper_chain_name(network):
     if not is_casper_network(network):
         raise ValueError(f"Unsupported Casper network: {network!r}")
     return network.split(":", 1)[1]
-

--- a/openclaw_x402/middleware.py
+++ b/openclaw_x402/middleware.py
@@ -3,7 +3,8 @@ OpenClaw x402 Flask Middleware.
 
 Drop-in x402 payment enforcement for any Flask API.
 Supports free mode ($0 pricing), real USDC payments via Coinbase facilitator,
-and graceful degradation when x402 libraries are not installed.
+real wCSPR payments on Casper via an x402 v2 facilitator, and graceful
+degradation when x402 libraries are not installed.
 
 Usage:
     from openclaw_x402 import X402Middleware
@@ -14,6 +15,14 @@ Usage:
     @x402.premium(price="10000", description="Premium data export")
     def premium_data():
         return jsonify({"data": "..."})
+
+    # Casper rail (amounts in motes, 9 decimals):
+    x402 = X402Middleware(app, rail="casper", treasury="00" + "ab" * 32)
+
+    @app.route("/api/premium/casper")
+    @x402.premium(price="7500000000", description="Premium data export")
+    def premium_casper():
+        return jsonify({"data": "..."})
 """
 
 import functools
@@ -22,6 +31,7 @@ import time
 
 from flask import jsonify, request
 
+from .casper import CasperPaymentError, CasperRail, CasperRailConfig
 from .config import (
     X402_NETWORK, USDC_BASE, FACILITATOR_URL, SWAP_INFO,
     is_free, has_cdp_credentials,
@@ -44,14 +54,32 @@ class X402Middleware:
 
     Args:
         app: Flask application (or None, call init_app later)
-        treasury: Base chain address to receive payments
+        treasury: Address receiving payments. A Base chain address for the
+            default ``base`` rail, or a Casper account hash for ``casper``.
         db_func: Optional callable returning a DB connection (for payment logging)
+        rail: Payment rail, ``"base"`` (USDC on Base) or ``"casper"``
+            (wCSPR CEP-18 on Casper).
+        casper_config: Optional :class:`~openclaw_x402.casper.CasperRailConfig`
+            overriding network, facilitator URL, asset and token metadata.
     """
 
-    def __init__(self, app=None, treasury="", db_func=None):
+    RAILS = ("base", "casper")
+
+    def __init__(self, app=None, treasury="", db_func=None, rail="base",
+                 casper_config=None):
+        if rail not in self.RAILS:
+            raise ValueError(f"Unsupported rail {rail!r}. Expected one of {self.RAILS}.")
         self.treasury = treasury
         self.db_func = db_func
+        self.rail = rail
         self._payment_table_created = False
+        self.casper = None
+        if rail == "casper":
+            config = casper_config or CasperRailConfig(treasury=treasury)
+            if treasury and not config.treasury:
+                config.treasury = treasury
+            self.casper = CasperRail(config)
+            self.treasury = self.casper.config.treasury or treasury
         if app is not None:
             self.init_app(app)
 
@@ -94,7 +122,7 @@ class X402Middleware:
 
         @app.route("/api/x402/status")
         def x402_status():
-            return jsonify({
+            payload = {
                 "x402_enabled": True,
                 "x402_lib": X402_LIB_AVAILABLE,
                 "cdp_configured": has_cdp_credentials(),
@@ -102,7 +130,14 @@ class X402Middleware:
                 "facilitator": FACILITATOR_URL,
                 "treasury": self.treasury,
                 "swap_info": SWAP_INFO,
-            })
+                "rail": self.rail,
+            }
+            if self.casper is not None:
+                casper_config = self.casper.config.to_dict()
+                payload["casper"] = casper_config
+                payload["network"] = casper_config["network"]
+                payload["facilitator"] = casper_config["facilitator"]
+            return jsonify(payload)
 
     def premium(self, price="0", description="Premium endpoint"):
         """
@@ -127,6 +162,15 @@ class X402Middleware:
                 # Check for x402 payment header
                 payment_header = request.headers.get("X-PAYMENT", "").strip()
 
+                # Casper rail: real facilitator verify + settle. Any failure
+                # falls through to a fresh 402 (fail closed, same as Base).
+                if self.casper is not None:
+                    if not payment_header:
+                        return self._payment_required(price, description)
+                    return self._casper_paid_request(
+                        f, args, kwargs, payment_header, price, description
+                    )
+
                 # SECURITY (fail closed): the facilitator verification path is
                 # not actually wired here — the imported x402 middleware is never
                 # invoked — so an X-PAYMENT header must NEVER be trusted on its
@@ -145,8 +189,47 @@ class X402Middleware:
             return wrapper
         return decorator
 
-    def _payment_required(self, price, description):
+    def _casper_paid_request(self, view, args, kwargs, payment_header, price,
+                             description):
+        """Verify + settle a Casper payment, then run the protected view."""
+        requirements = self.casper.payment_requirements(price, description, request.url)
+        try:
+            payload, settlement = self.casper.verify_and_settle(
+                payment_header, requirements
+            )
+        except CasperPaymentError as e:
+            log.warning(
+                "Casper payment rejected for %s: %s (%s)",
+                request.path, e.reason, e.message,
+            )
+            return self._payment_required(
+                price, description, reason=e.reason, message=e.message
+            )
+
+        authorization = payload.get("payload", {}).get("authorization", {})
+        payer = settlement.get("payer") or authorization.get("from", "")
+        self._log_payment(
+            payer=payer,
+            endpoint=request.path,
+            amount=str(price),
+            tx_hash=settlement.get("transaction", ""),
+            description=description,
+        )
+
+        response = self.app.make_response(view(*args, **kwargs))
+        response.headers["X-PAYMENT-RESPONSE"] = self.casper.settlement_receipt(
+            settlement
+        )
+        return response
+
+    def _payment_required(self, price, description, reason="", message=""):
         """Return HTTP 402 with x402 payment instructions."""
+        if self.casper is not None:
+            body = self.casper.challenge(price, description, request.url)
+            if reason:
+                body["reason"] = reason
+                body["message"] = message
+            return jsonify(body), 402
         return jsonify({
             "error": "Payment Required",
             "x402": {

--- a/tests/test_casper_middleware.py
+++ b/tests/test_casper_middleware.py
@@ -1,0 +1,284 @@
+import base64
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from flask import Flask, jsonify
+
+from openclaw_x402 import config
+from openclaw_x402.casper import CasperRailConfig
+from openclaw_x402.middleware import X402Middleware
+import openclaw_x402.casper as casper_module
+
+TREASURY = "00" + "ab" * 32
+PAYER = "00" + "cd" * 32
+ASSET = "ef" * 32
+PRICE_MOTES = "7500000000"  # 7.5 CSPR
+DEPLOY_HASH = "dd" * 32
+
+
+def casper_config(**overrides):
+    kwargs = {
+        "treasury": TREASURY,
+        "asset": ASSET,
+        "facilitator_url": "https://facilitator.example",
+    }
+    kwargs.update(overrides)
+    return CasperRailConfig(**kwargs)
+
+
+def payment_header():
+    payload = {
+        "x402Version": 2,
+        "scheme": "exact",
+        "network": config.CASPER_MAINNET,
+        "payload": {
+            "signature": "aa" * 65,
+            "publicKey": "01" + "bb" * 32,
+            "authorization": {
+                "from": PAYER,
+                "to": TREASURY,
+                "value": PRICE_MOTES,
+                "validAfter": "1710000000",
+                "validBefore": "1710000900",
+                "nonce": "cc" * 32,
+            },
+        },
+    }
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+VERIFY_OK = FakeResponse({"isValid": True, "payer": PAYER})
+SETTLE_OK = FakeResponse(
+    {
+        "success": True,
+        "transaction": DEPLOY_HASH,
+        "network": config.CASPER_MAINNET,
+        "payer": PAYER,
+    }
+)
+
+
+def create_casper_app(db_func=None, **config_overrides):
+    app = Flask(__name__)
+    x402 = X402Middleware(
+        app,
+        rail="casper",
+        treasury=TREASURY,
+        db_func=db_func,
+        casper_config=casper_config(**config_overrides),
+    )
+
+    @app.route("/premium")
+    @x402.premium(price=PRICE_MOTES, description="Premium export")
+    def premium_endpoint():
+        return jsonify({"ok": True})
+
+    @app.route("/free")
+    @x402.premium(price="0", description="Free endpoint")
+    def free_endpoint():
+        return jsonify({"ok": True})
+
+    return app
+
+
+class CasperRailSelectionTests(unittest.TestCase):
+    def test_default_rail_is_base_and_has_no_casper_rail(self):
+        middleware = X402Middleware(treasury="0xabc")
+        self.assertEqual(middleware.rail, "base")
+        self.assertIsNone(middleware.casper)
+
+    def test_unknown_rail_is_rejected(self):
+        with self.assertRaises(ValueError):
+            X402Middleware(treasury="0xabc", rail="dogecoin")
+
+    def test_casper_rail_defaults_to_cspr_cloud_facilitator(self):
+        middleware = X402Middleware(rail="casper", treasury=TREASURY)
+        self.assertEqual(
+            middleware.casper.config.facilitator_url,
+            "https://x402-facilitator.cspr.cloud",
+        )
+        self.assertEqual(middleware.casper.config.network, "casper:casper")
+
+    def test_status_endpoint_reports_casper_rail(self):
+        app = create_casper_app()
+        payload = app.test_client().get("/api/x402/status").get_json()
+
+        self.assertEqual(payload["rail"], "casper")
+        self.assertEqual(payload["network"], "casper:casper")
+        self.assertEqual(payload["facilitator"], "https://facilitator.example")
+        self.assertEqual(payload["casper"]["asset"], ASSET)
+        self.assertEqual(payload["casper"]["asset_decimals"], 9)
+        self.assertEqual(payload["casper"]["motes_per_cspr"], 1_000_000_000)
+        self.assertEqual(payload["casper"]["treasury"], TREASURY)
+
+    def test_base_rail_status_still_reports_base_network(self):
+        app = Flask(__name__)
+        X402Middleware(app, treasury="0xabc")
+        payload = app.test_client().get("/api/x402/status").get_json()
+
+        self.assertEqual(payload["rail"], "base")
+        self.assertEqual(payload["network"], config.X402_NETWORK)
+        self.assertNotIn("casper", payload)
+
+
+class CasperChallengeTests(unittest.TestCase):
+    def setUp(self):
+        self.client = create_casper_app().test_client()
+
+    def test_unpaid_request_returns_402_with_casper_accepts(self):
+        response = self.client.get("/premium", base_url="https://api.example.test")
+
+        self.assertEqual(response.status_code, 402)
+        body = response.get_json()
+        self.assertEqual(body["x402Version"], 2)
+        accepts = body["accepts"][0]
+        self.assertEqual(accepts["scheme"], "exact")
+        self.assertEqual(accepts["network"], "casper:casper")
+        self.assertEqual(accepts["payTo"], TREASURY)
+        self.assertEqual(accepts["amount"], PRICE_MOTES)
+        self.assertEqual(accepts["asset"], ASSET)
+        self.assertEqual(accepts["extra"]["decimals"], "9")
+        self.assertEqual(accepts["resource"], "https://api.example.test/premium")
+
+    def test_free_route_is_unaffected_by_the_casper_rail(self):
+        response = self.client.get("/free")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"ok": True})
+
+    def test_testnet_challenge_advertises_testnet_network(self):
+        client = create_casper_app(network=config.CASPER_TESTNET).test_client()
+        body = client.get("/premium").get_json()
+        self.assertEqual(body["accepts"][0]["network"], "casper:casper-test")
+
+
+class CasperPaidRequestTests(unittest.TestCase):
+    def test_verified_and_settled_payment_unlocks_the_route(self):
+        client = create_casper_app().test_client()
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=[VERIFY_OK, SETTLE_OK]
+        ) as post:
+            response = client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"ok": True})
+        self.assertEqual(post.call_count, 2)
+
+        receipt = json.loads(
+            base64.b64decode(response.headers["X-PAYMENT-RESPONSE"]).decode("utf-8")
+        )
+        self.assertTrue(receipt["success"])
+        self.assertEqual(receipt["transaction"], DEPLOY_HASH)
+
+    def test_fake_payment_header_still_returns_402(self):
+        client = create_casper_app().test_client()
+        with mock.patch.object(casper_module.httpx, "post") as post:
+            response = client.get("/premium", headers={"X-PAYMENT": "totally-fake"})
+
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(response.get_json()["reason"], "malformed_payload")
+        post.assert_not_called()
+
+    def test_facilitator_rejection_returns_402_with_reason(self):
+        client = create_casper_app().test_client()
+        rejection = FakeResponse(
+            {
+                "isValid": False,
+                "invalidReason": "invalid_signature",
+                "invalidMessage": "signature does not verify",
+            }
+        )
+        with mock.patch.object(casper_module.httpx, "post", return_value=rejection):
+            response = client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        self.assertEqual(response.status_code, 402)
+        body = response.get_json()
+        self.assertEqual(body["reason"], "invalid_signature")
+        self.assertEqual(body["message"], "signature does not verify")
+
+    def test_settlement_failure_fails_closed_with_402(self):
+        client = create_casper_app().test_client()
+        settle_failure = FakeResponse(
+            {
+                "success": False,
+                "errorReason": "put_deploy_failed",
+                "errorMessage": "node rejected deploy",
+            }
+        )
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=[VERIFY_OK, settle_failure]
+        ):
+            response = client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(response.get_json()["reason"], "put_deploy_failed")
+
+    def test_unreachable_facilitator_fails_closed_with_402(self):
+        client = create_casper_app().test_client()
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=OSError("connection refused")
+        ):
+            response = client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        self.assertEqual(response.status_code, 402)
+        self.assertEqual(response.get_json()["reason"], "facilitator_unreachable")
+
+
+class CasperPaymentLoggingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "payments.db"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def db_func(self):
+        return sqlite3.connect(self.db_path)
+
+    def test_settled_payment_is_logged_with_deploy_hash_and_motes(self):
+        client = create_casper_app(db_func=self.db_func).test_client()
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=[VERIFY_OK, SETTLE_OK]
+        ):
+            response = client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        self.assertEqual(response.status_code, 200)
+        with sqlite3.connect(self.db_path) as db:
+            row = db.execute(
+                "SELECT payer_address, endpoint, amount_usdc, tx_hash, description "
+                "FROM x402_payments"
+            ).fetchone()
+
+        self.assertEqual(
+            row, (PAYER, "/premium", PRICE_MOTES, DEPLOY_HASH, "Premium export")
+        )
+
+    def test_rejected_payment_is_not_logged(self):
+        client = create_casper_app(db_func=self.db_func).test_client()
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse({"isValid": False, "invalidReason": "expired"}),
+        ):
+            client.get("/premium", headers={"X-PAYMENT": payment_header()})
+
+        with sqlite3.connect(self.db_path) as db:
+            count = db.execute("SELECT COUNT(*) FROM x402_payments").fetchone()[0]
+
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_casper_rail.py
+++ b/tests/test_casper_rail.py
@@ -1,0 +1,399 @@
+import base64
+import json
+import unittest
+from unittest import mock
+
+from openclaw_x402 import config
+from openclaw_x402.casper import (
+    CasperPaymentError,
+    CasperRail,
+    CasperRailConfig,
+    cspr_to_motes,
+    is_valid_account_hash,
+    is_valid_package_hash,
+    motes_to_cspr,
+)
+import openclaw_x402.casper as casper_module
+
+TREASURY = "00" + "ab" * 32
+PAYER = "00" + "cd" * 32
+ASSET = "ef" * 32
+PRICE_MOTES = "7500000000"  # 7.5 CSPR
+
+
+def build_payload(value=PRICE_MOTES, to=TREASURY, network=config.CASPER_MAINNET):
+    return {
+        "x402Version": 2,
+        "scheme": "exact",
+        "network": network,
+        "payload": {
+            "signature": "aa" * 65,
+            "publicKey": "01" + "bb" * 32,
+            "authorization": {
+                "from": PAYER,
+                "to": to,
+                "value": value,
+                "validAfter": "1710000000",
+                "validBefore": "1710000900",
+                "nonce": "cc" * 32,
+            },
+        },
+    }
+
+
+def encode_header(payload):
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+
+
+class FakeResponse:
+    """Minimal stand-in for an httpx.Response."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def make_rail(**overrides):
+    kwargs = {
+        "treasury": TREASURY,
+        "asset": ASSET,
+        "facilitator_url": "https://x402-facilitator.cspr.cloud",
+    }
+    kwargs.update(overrides)
+    return CasperRail(CasperRailConfig(**kwargs))
+
+
+class MoteConversionTests(unittest.TestCase):
+    def test_one_cspr_is_one_billion_motes(self):
+        self.assertEqual(cspr_to_motes(1), "1000000000")
+        self.assertEqual(int(config.MOTES_PER_CSPR), 1_000_000_000)
+
+    def test_fractional_cspr_converts_without_float_error(self):
+        self.assertEqual(cspr_to_motes("7.5"), "7500000000")
+        self.assertEqual(cspr_to_motes("0.000000001"), "1")
+
+    def test_round_trip_preserves_value(self):
+        for cspr in ("0.1", "1", "7.5", "12345.678901234"):
+            with self.subTest(cspr=cspr):
+                self.assertEqual(motes_to_cspr(cspr_to_motes(cspr)), cspr)
+
+    def test_sub_mote_precision_is_rejected(self):
+        with self.assertRaises(ValueError):
+            cspr_to_motes("0.0000000001")
+
+    def test_negative_amount_is_rejected(self):
+        with self.assertRaises(ValueError):
+            cspr_to_motes("-1")
+
+    def test_fractional_motes_are_rejected(self):
+        with self.assertRaises(ValueError):
+            motes_to_cspr("1.5")
+
+
+class AddressValidationTests(unittest.TestCase):
+    def test_account_hash_must_be_prefixed_and_64_hex(self):
+        self.assertTrue(is_valid_account_hash(TREASURY))
+        self.assertTrue(is_valid_account_hash("01" + "ff" * 32))
+        self.assertFalse(is_valid_account_hash(""))
+        self.assertFalse(is_valid_account_hash("02" + "ab" * 32))
+        self.assertFalse(is_valid_account_hash("00" + "ab" * 31))
+        self.assertFalse(is_valid_account_hash("0x" + "ab" * 32))
+
+    def test_package_hash_is_bare_64_hex(self):
+        self.assertTrue(is_valid_package_hash(ASSET))
+        self.assertFalse(is_valid_package_hash("00" + ASSET))
+        self.assertFalse(is_valid_package_hash("zz" * 32))
+
+
+class RailConfigTests(unittest.TestCase):
+    def test_defaults_point_at_cspr_cloud_facilitator_and_mainnet(self):
+        rail_config = CasperRailConfig(treasury=TREASURY)
+        self.assertEqual(
+            rail_config.facilitator_url, "https://x402-facilitator.cspr.cloud"
+        )
+        self.assertEqual(rail_config.network, config.CASPER_MAINNET)
+        self.assertEqual(rail_config.asset_decimals, 9)
+
+    def test_testnet_is_supported(self):
+        rail_config = CasperRailConfig(
+            treasury=TREASURY, network=config.CASPER_TESTNET
+        )
+        self.assertEqual(rail_config.network, "casper:casper-test")
+        self.assertEqual(config.casper_chain_name(rail_config.network), "casper-test")
+
+    def test_unknown_network_is_rejected(self):
+        with self.assertRaises(ValueError):
+            CasperRailConfig(treasury=TREASURY, network="eip155:8453")
+
+    def test_trailing_slash_is_stripped_from_facilitator_url(self):
+        rail_config = CasperRailConfig(
+            treasury=TREASURY, facilitator_url="https://facilitator.example/"
+        )
+        self.assertEqual(rail_config.facilitator_url, "https://facilitator.example")
+
+
+class PaymentRequirementsTests(unittest.TestCase):
+    def test_requirements_match_x402_v2_casper_shape(self):
+        rail = make_rail()
+        requirements = rail.payment_requirements(
+            PRICE_MOTES, "Premium export", "https://api.example.test/premium"
+        )
+
+        self.assertEqual(requirements["scheme"], "exact")
+        self.assertEqual(requirements["network"], "casper:casper")
+        self.assertEqual(requirements["payTo"], TREASURY)
+        self.assertEqual(requirements["amount"], PRICE_MOTES)
+        self.assertEqual(requirements["maxAmountRequired"], PRICE_MOTES)
+        self.assertEqual(requirements["asset"], ASSET)
+        self.assertEqual(requirements["extra"]["decimals"], "9")
+        self.assertEqual(requirements["extra"]["name"], "wCSPR")
+        self.assertEqual(requirements["extra"]["version"], "1")
+        self.assertEqual(requirements["maxTimeoutSeconds"], 900)
+
+    def test_challenge_wraps_requirements_in_accepts_list(self):
+        rail = make_rail()
+        challenge = rail.challenge(
+            PRICE_MOTES, "Premium export", "https://api.example.test/premium"
+        )
+
+        self.assertEqual(challenge["x402Version"], 2)
+        self.assertEqual(challenge["error"], "Payment Required")
+        self.assertEqual(len(challenge["accepts"]), 1)
+        self.assertEqual(challenge["accepts"][0]["payTo"], TREASURY)
+
+
+class PaymentHeaderDecodingTests(unittest.TestCase):
+    def test_base64_json_header_is_decoded(self):
+        payload = build_payload()
+        self.assertEqual(
+            CasperRail.decode_payment_header(encode_header(payload)), payload
+        )
+
+    def test_raw_json_header_is_accepted(self):
+        payload = build_payload()
+        self.assertEqual(
+            CasperRail.decode_payment_header(json.dumps(payload)), payload
+        )
+
+    def test_empty_header_is_malformed(self):
+        with self.assertRaises(CasperPaymentError) as ctx:
+            CasperRail.decode_payment_header("   ")
+        self.assertEqual(ctx.exception.reason, "malformed_payload")
+
+    def test_garbage_header_is_malformed(self):
+        with self.assertRaises(CasperPaymentError) as ctx:
+            CasperRail.decode_payment_header("not-a-payment")
+        self.assertEqual(ctx.exception.reason, "malformed_payload")
+
+    def test_non_object_json_is_malformed(self):
+        with self.assertRaises(CasperPaymentError) as ctx:
+            CasperRail.decode_payment_header(
+                base64.b64encode(b"[1, 2, 3]").decode("ascii")
+            )
+        self.assertEqual(ctx.exception.reason, "malformed_payload")
+
+
+class VerifyTests(unittest.TestCase):
+    def setUp(self):
+        self.rail = make_rail()
+        self.requirements = self.rail.payment_requirements(
+            PRICE_MOTES, "Premium export", "https://api.example.test/premium"
+        )
+
+    def test_verify_posts_x402_v2_body_to_facilitator(self):
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse({"isValid": True, "payer": PAYER}),
+        ) as post:
+            result = self.rail.verify(build_payload(), self.requirements)
+
+        self.assertTrue(result["isValid"])
+        url, = post.call_args[0]
+        body = post.call_args[1]["json"]
+        self.assertEqual(url, "https://x402-facilitator.cspr.cloud/verify")
+        self.assertEqual(body["x402Version"], 2)
+        self.assertEqual(body["paymentRequirements"], self.requirements)
+        self.assertEqual(body["paymentPayload"]["network"], "casper:casper")
+
+    def test_facilitator_rejection_raises_with_reason(self):
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse(
+                {
+                    "isValid": False,
+                    "invalidReason": "invalid_signature",
+                    "invalidMessage": "bad sig",
+                }
+            ),
+        ):
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(build_payload(), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "invalid_signature")
+        self.assertEqual(ctx.exception.message, "bad sig")
+
+    def test_amount_mismatch_is_caught_locally_without_network_call(self):
+        with mock.patch.object(casper_module.httpx, "post") as post:
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(build_payload(value="1"), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "amount_mismatch")
+        post.assert_not_called()
+
+    def test_pay_to_mismatch_is_caught_locally(self):
+        with mock.patch.object(casper_module.httpx, "post") as post:
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(
+                    build_payload(to="00" + "11" * 32), self.requirements
+                )
+
+        self.assertEqual(ctx.exception.reason, "pay_to_mismatch")
+        post.assert_not_called()
+
+    def test_network_mismatch_is_caught_locally(self):
+        with mock.patch.object(casper_module.httpx, "post") as post:
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(
+                    build_payload(network=config.CASPER_TESTNET), self.requirements
+                )
+
+        self.assertEqual(ctx.exception.reason, "network_mismatch")
+        post.assert_not_called()
+
+    def test_missing_authorization_field_is_malformed(self):
+        payload = build_payload()
+        del payload["payload"]["authorization"]["nonce"]
+        with mock.patch.object(casper_module.httpx, "post") as post:
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(payload, self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "malformed_payload")
+        post.assert_not_called()
+
+    def test_unreachable_facilitator_fails_closed(self):
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=OSError("connection refused")
+        ):
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(build_payload(), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "facilitator_unreachable")
+
+    def test_non_200_facilitator_response_fails_closed(self):
+        with mock.patch.object(
+            casper_module.httpx, "post", return_value=FakeResponse({}, status_code=502)
+        ):
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(build_payload(), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "facilitator_error")
+
+    def test_non_json_facilitator_response_fails_closed(self):
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse(ValueError("not json")),
+        ):
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify(build_payload(), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "facilitator_error")
+
+
+class SettleTests(unittest.TestCase):
+    def setUp(self):
+        self.rail = make_rail()
+        self.requirements = self.rail.payment_requirements(
+            PRICE_MOTES, "Premium export", "https://api.example.test/premium"
+        )
+
+    def test_settle_returns_deploy_hash(self):
+        settle_response = {
+            "success": True,
+            "transaction": "dd" * 32,
+            "network": "casper:casper",
+            "payer": PAYER,
+        }
+        with mock.patch.object(
+            casper_module.httpx, "post", return_value=FakeResponse(settle_response)
+        ) as post:
+            result = self.rail.settle(build_payload(), self.requirements)
+
+        self.assertEqual(result["transaction"], "dd" * 32)
+        self.assertEqual(
+            post.call_args[0][0], "https://x402-facilitator.cspr.cloud/settle"
+        )
+
+    def test_failed_settlement_raises_with_error_reason(self):
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse(
+                {
+                    "success": False,
+                    "errorReason": "put_deploy_failed",
+                    "errorMessage": "node rejected deploy",
+                }
+            ),
+        ):
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.settle(build_payload(), self.requirements)
+
+        self.assertEqual(ctx.exception.reason, "put_deploy_failed")
+
+    def test_verify_and_settle_calls_both_endpoints_in_order(self):
+        responses = [
+            FakeResponse({"isValid": True, "payer": PAYER}),
+            FakeResponse({"success": True, "transaction": "dd" * 32, "payer": PAYER}),
+        ]
+        with mock.patch.object(
+            casper_module.httpx, "post", side_effect=responses
+        ) as post:
+            payload, settlement = self.rail.verify_and_settle(
+                encode_header(build_payload()), self.requirements
+            )
+
+        called = [call[0][0] for call in post.call_args_list]
+        self.assertEqual(
+            called,
+            [
+                "https://x402-facilitator.cspr.cloud/verify",
+                "https://x402-facilitator.cspr.cloud/settle",
+            ],
+        )
+        self.assertEqual(settlement["transaction"], "dd" * 32)
+        self.assertEqual(payload["payload"]["authorization"]["from"], PAYER)
+
+    def test_verify_failure_short_circuits_settlement(self):
+        with mock.patch.object(
+            casper_module.httpx,
+            "post",
+            return_value=FakeResponse(
+                {"isValid": False, "invalidReason": "payload_expired"}
+            ),
+        ) as post:
+            with self.assertRaises(CasperPaymentError) as ctx:
+                self.rail.verify_and_settle(
+                    encode_header(build_payload()), self.requirements
+                )
+
+        self.assertEqual(ctx.exception.reason, "payload_expired")
+        self.assertEqual(post.call_count, 1)
+
+    def test_settlement_receipt_is_base64_json(self):
+        settle_response = {"success": True, "transaction": "dd" * 32}
+        receipt = CasperRail.settlement_receipt(settle_response)
+        self.assertEqual(
+            json.loads(base64.b64decode(receipt).decode("utf-8")), settle_response
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Casper as a third payment rail to the Flask middleware, alongside USDC-on-Base and RTC-on-RustChain.

The README already frames this project as "same pattern, two payment rails" — the seam between the challenge builder, the facilitator call, and the `@x402.premium` decorator is clean enough that a third rail mostly meant filling in the network-specific pieces rather than restructuring anything. Casper is a reasonable next rail: it has a live x402 v2 facilitator (`https://x402-facilitator.cspr.cloud`), a CEP-18 settlement token (wCSPR), and the same `exact` scheme the spec defines for Base, so buyer agents that already speak x402 need no new client logic beyond signing for a different chain.

Nothing about the existing rails changes. `X402Middleware(app, treasury=...)` behaves exactly as before; the Casper path is opt-in via `rail="casper"`.

## What was added

- **`openclaw_x402/casper.py`** — the rail itself:
  - `CasperRailConfig` — network, facilitator URL, CEP-18 asset, token name/version, timeout. All configurable, cspr.cloud facilitator and `casper:casper` mainnet as defaults.
  - `CasperRail` — builds the x402 v2 402 challenge (`accepts[]` with `scheme`/`network`/`payTo`/`amount`/`asset`/`extra`), decodes the `X-PAYMENT` header, and calls the facilitator's `POST /verify` and `POST /settle`.
  - `cspr_to_motes` / `motes_to_cspr` — `Decimal`-based, no float rounding. CSPR is 9 decimals (`1 CSPR = 1_000_000_000 motes`), and every price the middleware handles is in motes. Sub-mote precision raises rather than silently truncating.
  - `is_valid_account_hash` / `is_valid_package_hash` — Casper account hashes are `00`/`01` + 64 hex; CEP-18 package hashes are bare 64 hex.
- **`openclaw_x402/config.py`** — Casper constants and `CASPER_*` environment variables, plus `is_casper_network` / `casper_chain_name`.
- **`openclaw_x402/middleware.py`** — `rail=` argument (`"base"` default, `"casper"`), the verify→settle→run-view path, and `/api/x402/status` reporting the active rail.
- **`examples/casper_flask_app.py`** — runnable Flask app metered in wCSPR.
- **README** — an "x402 on Casper" section following the style of the existing rail docs, plus the new env vars.

## Fail-closed behaviour

This follows the posture set by #12 and #14. On the Casper rail, a request is only let through after the facilitator returns `isValid: true` **and** a successful settlement with a deploy hash. Every other outcome — malformed header, rejected payload, failed settlement, unreachable or non-200 facilitator — produces a fresh 402 with the facilitator's `reason`/`message`. There is no path where an unverified `X-PAYMENT` header grants access.

Payload shape is also pre-checked locally (`payTo` match, exact amount match, network match, required authorization fields) before anything goes over the wire, so a bad request never costs a facilitator round-trip.

On success the response carries `X-PAYMENT-RESPONSE` with a base64 settlement receipt, and the payment is recorded in `x402_payments` with the real on-chain payer and Casper deploy hash — the payer is read from the facilitator's settle response, never from the client-supplied `from`.

## Tests

Two new files following the existing `unittest`-under-pytest style, mirroring how the Base rail is covered in `test_middleware_config.py` and `test_manual_mode_fail_closed.py`. All facilitator HTTP calls are mocked; **no test touches the network**.

- `tests/test_casper_rail.py` (33 tests) — mote conversion and round-tripping, address/package-hash validation, config defaults and network validation, `accepts[]` shape, `X-PAYMENT` decoding (base64 and raw JSON), verify/settle request bodies and endpoint ordering, and every failure reason.
- `tests/test_casper_middleware.py` (15 tests) — rail selection, status endpoint for both rails, 402 challenge contents on mainnet and testnet, the full paid-request flow, four distinct fail-closed paths, and payment logging (including that a rejected payment logs nothing).

```
$ pytest -q
................................................................ [ 79%]
.................                                                        [100%]
81 passed, 8 subtests passed in 0.34s
```

That is 33 pre-existing tests plus 48 new ones. The suite was green on clean `main` before these changes and is green after; no pre-existing test was modified.

`flake8 --max-line-length=100` is clean on every file this PR adds or touches.

## Notes

- Amounts are motes end to end. The `x402_payments.amount_usdc` column stores the mote value on this rail — I left the column name alone rather than migrating a shared schema in a feature PR, but happy to rename it to something rail-neutral if you'd prefer.
- The middleware holds no keys and never signs. The payer signs the `TransferWithAuthorization` payload client-side; the facilitator pays gas to submit the CEP-18 `transfer_with_authorization` deploy.
- Request/response shapes follow the x402 v2 Casper mechanism as implemented in `make-software/casper-x402`.
