### PR TITLE
fix(middleware): close DB handles and keep Flask optional

### DIFF
--- a/openclaw_x402/__init__.py
+++ b/openclaw_x402/__init__.py
@@ -13,13 +13,35 @@ Usage:
         return jsonify({"data": "..."})
 """
 
+from typing import TYPE_CHECKING
+
 __version__ = "0.2.0"
 
-from .middleware import X402Middleware
 from .config import (
     X402_NETWORK, USDC_BASE, WRTC_BASE, AERODROME_POOL,
     FACILITATOR_URL, SWAP_INFO, is_free, has_cdp_credentials,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - type-checker only
+    from .middleware import X402Middleware
+
+
+def __getattr__(name):
+    """Lazily expose Flask-only middleware without breaking MCP-only installs."""
+    if name != "X402Middleware":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    try:
+        from .middleware import X402Middleware
+    except ModuleNotFoundError as exc:
+        if exc.name == "flask":
+            raise ImportError(
+                "X402Middleware requires Flask. Install the optional extra with "
+                "`pip install openclaw-x402[flask]` or install Flask directly."
+            ) from exc
+        raise
+    return X402Middleware
+
 
 __all__ = [
     "X402Middleware",

--- a/openclaw_x402/middleware.py
+++ b/openclaw_x402/middleware.py
@@ -70,6 +70,7 @@ class X402Middleware:
         """Create x402_payments table if DB function is provided."""
         if not self.db_func or self._payment_table_created:
             return
+        db = None
         try:
             db = self.db_func()
             db.execute("""
@@ -88,6 +89,12 @@ class X402Middleware:
             self._payment_table_created = True
         except Exception as e:
             log.warning("Failed to create x402_payments table: %s", e)
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except Exception as e:
+                    log.warning("Failed to close x402 payment database: %s", e)
 
     def _register_routes(self, app):
         """Register x402 status endpoint."""
@@ -165,6 +172,7 @@ class X402Middleware:
         """Log a payment to the database."""
         if not self.db_func:
             return
+        db = None
         try:
             db = self.db_func()
             db.execute(
@@ -175,3 +183,9 @@ class X402Middleware:
             db.commit()
         except Exception as e:
             log.warning("Failed to log x402 payment: %s", e)
+        finally:
+            if db is not None:
+                try:
+                    db.close()
+                except Exception as e:
+                    log.warning("Failed to close x402 payment database: %s", e)

--- a/tests/test_middleware_config.py
+++ b/tests/test_middleware_config.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 import sqlite3
 import tempfile
 import unittest
@@ -45,7 +46,7 @@ class MiddlewareHelperTests(unittest.TestCase):
         middleware = X402Middleware(app, treasury="0xabc", db_func=self.db_func)
 
         self.assertTrue(middleware._payment_table_created)
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             row = db.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
                 ("x402_payments",),
@@ -65,7 +66,7 @@ class MiddlewareHelperTests(unittest.TestCase):
             description="Premium export",
         )
 
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             row = db.execute(
                 """
                 SELECT payer_address, endpoint, amount_usdc, tx_hash, network, description

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,60 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_mcp_server_import_does_not_require_flask():
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        class BlockFlask(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "flask" or fullname.startswith("flask."):
+                    raise ModuleNotFoundError("No module named 'flask'", name="flask")
+                return None
+
+        sys.meta_path.insert(0, BlockFlask())
+        import openclaw_x402.mcp_server
+        print("mcp import ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "mcp import ok" in result.stdout
+
+
+def test_top_level_middleware_export_explains_missing_flask():
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        class BlockFlask(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "flask" or fullname.startswith("flask."):
+                    raise ModuleNotFoundError("No module named 'flask'", name="flask")
+                return None
+
+        sys.meta_path.insert(0, BlockFlask())
+        from openclaw_x402 import X402Middleware
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "pip install openclaw-x402[flask]" in result.stderr


### PR DESCRIPTION
## Summary

Refs Scottcjn/rustchain-bounties#71.

This PR fixes two related reliability/security issues around the Flask middleware boundary:

- keeps the core MCP package importable without installing the optional Flask extra
- closes sqlite connections returned by `db_func` after middleware setup and payment logging, preventing locked `payments.db` files on Windows and long-lived handles in host apps

## Reproduction before the patch

From a clean checkout:

- `uv run --with pytest pytest -q` failed while loading `tests/conftest.py` with `ModuleNotFoundError: No module named 'flask'`, because `openclaw_x402.__init__` eagerly imported the optional Flask middleware.
- `uv run --with pytest --with flask pytest -q` ran most tests but failed two middleware sqlite tests on Windows during tempdir cleanup with WinError 32 because the production middleware opened sqlite handles via `db_func()` and did not close them.

## What changed

- `openclaw_x402.__init__` now lazily exposes `X402Middleware` via `__getattr__`, so MCP-only users can import the package/server without Flask installed.
- If a caller explicitly imports `X402Middleware` without Flask, the package raises an actionable error explaining to install `openclaw-x402[flask]` or Flask directly.
- `_ensure_payment_table()` and `_log_payment()` now close `db_func()` connections in a `finally` block.
- Middleware sqlite tests now close their assertion connections explicitly with `contextlib.closing`.
- Added regression tests proving MCP imports do not require Flask and that the missing-Flask middleware path gives a useful message.

## Verification

- `uv run --with pytest --with flask pytest -q` -> 35 passed, 4 subtests passed
- `uv run --with pytest pytest -q tests\test_mcp_payment_helpers.py tests\test_mcp_payment_replay.py tests\test_package_imports.py` -> 16 passed
- `python -m py_compile openclaw_x402\__init__.py openclaw_x402\middleware.py tests\test_package_imports.py tests\test_middleware_config.py`
- `git diff --check`

Payout wallet if accepted: `RTC973498f72747cd1637e395521319c0ad61c0f68c`

AI-assisted fix; manually reproduced and verified on Windows.