### PR TITLE
fix(mcp): reject malformed payment token amounts

### DIFF
--- a/openclaw_x402/mcp_server.py
+++ b/openclaw_x402/mcp_server.py
@@ -32,6 +32,7 @@ Or in Claude Desktop config:
 import hashlib
 import json
 import logging
+import math
 import os
 import sqlite3
 import time
@@ -105,6 +106,19 @@ def _consume_tx(tx_id: str, tool_name: str) -> str:
         return "unavailable"
 
 
+def _parse_payment_amount(value) -> float | None:
+    """Parse a JSON payment amount and reject values the ledger cannot represent."""
+    if isinstance(value, bool):
+        return None
+    try:
+        amount = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(amount):
+        return None
+    return amount
+
+
 def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -> dict:
     """
     Verify an RTC payment token against RustChain.
@@ -115,9 +129,20 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
         token = json.loads(payment_token)
     except (json.JSONDecodeError, TypeError):
         return {"valid": False, "error": "Malformed payment token. Expected JSON."}
+    if not isinstance(token, dict):
+        return {"valid": False, "error": "Malformed payment token. Expected JSON object."}
 
     tx_id = token.get("tx_id", "")
-    amount = float(token.get("amount", 0))
+    if not isinstance(tx_id, str) or not tx_id.strip():
+        return {"valid": False, "error": "Malformed payment token. Expected non-empty tx_id."}
+    tx_id = tx_id.strip()
+
+    amount = _parse_payment_amount(token.get("amount", 0))
+    if amount is None:
+        return {
+            "valid": False,
+            "error": "Malformed payment token amount. Expected a finite number.",
+        }
     # NOTE: the client-supplied "from" is intentionally ignored; the verified
     # sender is read from the on-chain tx below.
 
@@ -138,8 +163,13 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
             tx_data = resp.json()
             chain_to = tx_data.get("to")
             chain_from = tx_data.get("from")
-            chain_amount = float(tx_data.get("amount", 0))
-            if chain_to == TREASURY_WALLET and chain_amount >= expected_price and chain_from:
+            chain_amount = _parse_payment_amount(tx_data.get("amount", 0))
+            if (
+                chain_to == TREASURY_WALLET
+                and chain_amount is not None
+                and chain_amount >= expected_price
+                and chain_from
+            ):
                 # A confirmed transaction stays confirmed forever, so it would
                 # otherwise pay for unlimited calls. Spend it exactly once.
                 claim = _consume_tx(tx_id, tool_name)
@@ -236,6 +266,8 @@ def _paid_result(data: dict, price: float, tx_token: str) -> str:
     try:
         token = json.loads(tx_token)
     except Exception:
+        token = {}
+    if not isinstance(token, dict):
         token = {}
     return json.dumps(
         {

--- a/tests/test_mcp_payment_helpers.py
+++ b/tests/test_mcp_payment_helpers.py
@@ -21,6 +21,60 @@ def test_verify_payment_rejects_malformed_json_token():
     }
 
 
+def test_verify_payment_rejects_non_object_json_token_before_network_call(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("network verification should not run for malformed payment token")
+
+    monkeypatch.setattr(mcp_server.httpx, "get", fail_if_called)
+
+    result = mcp_server._verify_payment(
+        json.dumps(["tx-ok", "payer", 1.0]),
+        0.1,
+        "premium_search",
+    )
+
+    assert result == {
+        "valid": False,
+        "error": "Malformed payment token. Expected JSON object.",
+    }
+
+
+def test_verify_payment_rejects_invalid_client_amount_before_network_call(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("network verification should not run for malformed payment amount")
+
+    monkeypatch.setattr(mcp_server.httpx, "get", fail_if_called)
+
+    result = mcp_server._verify_payment(
+        json.dumps({"tx_id": "tx-bad-amount", "from": "payer", "amount": "many"}),
+        0.1,
+        "premium_search",
+    )
+
+    assert result == {
+        "valid": False,
+        "error": "Malformed payment token amount. Expected a finite number.",
+    }
+
+
+def test_verify_payment_rejects_missing_tx_id_before_network_call(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("network verification should not run without a tx_id")
+
+    monkeypatch.setattr(mcp_server.httpx, "get", fail_if_called)
+
+    result = mcp_server._verify_payment(
+        json.dumps({"from": "payer", "amount": 1.0}),
+        0.1,
+        "premium_search",
+    )
+
+    assert result == {
+        "valid": False,
+        "error": "Malformed payment token. Expected non-empty tx_id.",
+    }
+
+
 def test_verify_payment_rejects_insufficient_amount_before_network_call(monkeypatch):
     def fail_if_called(*args, **kwargs):
         raise AssertionError("network verification should not run for insufficient payment")
@@ -99,6 +153,28 @@ def test_verify_payment_rejects_when_chain_sender_missing(monkeypatch):
         json.dumps({"tx_id": "tx-nofrom", "from": "client", "amount": 1.0}), 0.25, "bcos_report"
     )
     assert result["valid"] is False
+
+
+def test_verify_payment_rejects_non_finite_chain_amount(monkeypatch):
+    monkeypatch.setattr(mcp_server, "TREASURY_WALLET", "openclaw-treasury")
+    monkeypatch.setattr(
+        mcp_server.httpx,
+        "get",
+        lambda *a, **k: DummyResponse(
+            200, {"to": "openclaw-treasury", "amount": "Infinity", "from": "chain-sender"}
+        ),
+    )
+
+    result = mcp_server._verify_payment(
+        json.dumps({"tx_id": "tx-infinite", "from": "payer", "amount": 1.0}),
+        0.25,
+        "bcos_report",
+    )
+
+    assert result == {
+        "valid": False,
+        "error": "Transaction destination, amount, or sender could not be verified.",
+    }
 
 
 def test_verify_payment_fails_closed_on_network_exception(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes Scottcjn/openclaw-x402#18.

This hardens the paid MCP payment verifier so malformed x402 payment tokens fail closed with structured `payment_failed` responses instead of uncaught parser/type errors.

## What changed

- Require `payment_token` to decode to a JSON object.
- Reject missing/blank `tx_id` before making a RustChain node request.
- Parse client token amounts through a finite-number helper, rejecting booleans, invalid strings, `NaN`, and infinities.
- Reuse the same finite-number guard for the verified on-chain ledger amount before spending/accepting a tx.
- Harden `_paid_result()` against non-object token JSON for consistency.
- Add regression tests for non-object tokens, invalid client amounts, missing tx ids, and non-finite chain amounts.

## Why

Before this patch:

- `payment_token='["tx", "payer", 1.0]'` raised `AttributeError` at `token.get(...)`.
- `amount="many"` raised `ValueError` at `float(...)`.
- an omitted `tx_id` still hit `/api/tx/`.
- a ledger amount of `"Infinity"` parsed to `inf` and could validate as paid if `to`/`from` matched.

Paid MCP tools should reject these cases before execution and before marking any transaction spent.

## Validation

- `uv run --no-project --with pytest --with flask --with fastmcp --with httpx python -m pytest -q tests\\test_mcp_payment_helpers.py tests\\test_mcp_payment_replay.py` -> 18 passed
- `uv run --no-project --with pytest --with flask --with fastmcp --with httpx python -m pytest -q tests\\test_config.py tests\\test_manual_mode_fail_closed.py tests\\test_mcp_payment_helpers.py tests\\test_mcp_payment_replay.py` -> 30 passed, 4 subtests passed
- `python -m py_compile openclaw_x402\\mcp_server.py tests\\test_mcp_payment_helpers.py`
- `git diff --check` (only existing CRLF warning on Windows)