### PR TITLE
fix(security): enable TLS verification by default in openclaw_x402 mcp_server

### DIFF
--- a/openclaw_x402/mcp_server.py
+++ b/openclaw_x402/mcp_server.py
@@ -28,6 +28,16 @@ Or in Claude Desktop config:
       }
     }
 """
+# OPENCLAW_INSECURE_SKIP_TLS_VERIFY=1 re-enables the historical
+# verify=False behaviour for self-hosted nodes with private CA certs.
+import os as _os_tls
+
+_INSECURE_TLS = _os_tls.getenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", "").lower() in (
+    "1", "true", "yes"
+)
+_VERIFY = not _INSECURE_TLS
+
+
 
 import hashlib
 import json
@@ -131,7 +141,7 @@ def _verify_payment(payment_token: str, expected_price: float, tool_name: str) -
     try:
         resp = httpx.get(
             f"{RUSTCHAIN_NODE}/api/tx/{tx_id}",
-            verify=False,
+            verify=_VERIFY,
             timeout=10,
         )
         if resp.status_code == 200:
@@ -272,7 +282,7 @@ def premium_search(query: str = "", payment_token: str = "") -> str:
         resp = httpx.get(
             f"{RUSTCHAIN_NODE}/api/ledger",
             params={"q": query, "limit": 20},
-            verify=False,
+            verify=_VERIFY,
             timeout=10,
         )
         if resp.status_code == 200:
@@ -301,7 +311,7 @@ def miner_profile(miner_id: str = "", payment_token: str = "") -> str:
     try:
         resp = httpx.get(
             f"{RUSTCHAIN_NODE}/api/miner/{miner_id}",
-            verify=False,
+            verify=_VERIFY,
             timeout=10,
         )
         if resp.status_code == 200:
@@ -349,7 +359,7 @@ def bcos_report(repo: str = "", payment_token: str = "") -> str:
 def network_status() -> str:
     """[FREE] Check RustChain network health. No payment required."""
     try:
-        resp = httpx.get(f"{RUSTCHAIN_NODE}/health", verify=False, timeout=10)
+        resp = httpx.get(f"{RUSTCHAIN_NODE}/health", verify=_VERIFY, timeout=10)
         if resp.status_code == 200:
             return json.dumps(resp.json(), indent=2)
     except Exception as e:

--- a/tests/test_mcp_payment_helpers.py
+++ b/tests/test_mcp_payment_helpers.py
@@ -42,7 +42,9 @@ def test_verify_payment_accepts_matching_confirmed_ledger_transaction(monkeypatc
 
     def fake_get(url, verify, timeout):
         assert url.endswith("/api/tx/tx-ok")
-        assert verify is False
+        # TLS verification must be on by default; OPENCLAW_INSECURE_SKIP_TLS_VERIFY
+        # is the only way to turn it off.
+        assert verify is True
         assert timeout == 10
         # Ledger reports the real sender + amount; client claims differ below.
         return DummyResponse(

--- a/tests/test_mcp_tls_default.py
+++ b/tests/test_mcp_tls_default.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for openclaw_x402.mcp_server TLS verification."""
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", raising=False)
+    yield
+
+
+class TestVerifyDefault:
+    def test_default_is_secure(self, monkeypatch):
+        import importlib
+        import openclaw_x402.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+        assert mcp_server._VERIFY is True
+        assert mcp_server._INSECURE_TLS is False
+
+    def test_env_one_overrides(self, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", "1")
+        import importlib
+        import openclaw_x402.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+        assert mcp_server._VERIFY is False
+        assert mcp_server._INSECURE_TLS is True
+
+    def test_env_true_overrides(self, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", "true")
+        import importlib
+        import openclaw_x402.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+        assert mcp_server._VERIFY is False
+
+    def test_env_yes_overrides(self, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", "yes")
+        import importlib
+        import openclaw_x402.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+        assert mcp_server._VERIFY is False
+
+    def test_env_zero_does_not_override(self, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_INSECURE_SKIP_TLS_VERIFY", "0")
+        import importlib
+        import openclaw_x402.mcp_server as mcp_server
+        importlib.reload(mcp_server)
+        assert mcp_server._VERIFY is True
+
+
+class TestVerifyIsPassedThrough:
+    def test_tx_lookup_uses_resolved_verify(self, monkeypatch):
+        import openclaw_x402.mcp_server as mcp_server
+        seen = {}
+
+        def fake_get(url, verify, timeout):
+            seen["url"] = url
+            seen["verify"] = verify
+            class R:
+                status_code = 200
+                def json(self_inner):
+                    return {"to": mcp_server.TREASURY_WALLET, "from": "chain-sender", "amount": "0.25"}
+            return R()
+
+        monkeypatch.setattr(mcp_server, "TREASURY_WALLET", "openclaw-treasury")
+        monkeypatch.setattr(mcp_server.httpx, "get", fake_get)
+
+        mcp_server._verify_payment(
+            '{"tx_id": "tx-x", "from": "client", "amount": 0.25}',
+            0.25,
+            "bcos_report",
+        )
+
+        assert seen["verify"] is True


### PR DESCRIPTION
## Summary

`openclaw_x402/mcp_server.py` had four `httpx.get(..., verify=False, ...)` calls -- tx lookup, ledger search, miner profile, and network_status health. Every paid RPC thus travelled over an unauthenticated TLS channel; a passive MITM on the path could forge ledger entries and steal RTC.

## Fix

- Insert a module-level helper that resolves `_VERIFY` from the `OPENCLAW_INSECURE_SKIP_TLS_VERIFY` env var. Default is `True`.
- The values `"1"` / `"true"` / `"yes"` re-enable the historical `verify=False` behaviour for self-hosted nodes with private CA certs.
- Re-point all four `httpx.get` calls at `_VERIFY`.
- Update `tests/test_mcp_payment_helpers.py` to assert the new `verify=True` default in its fake transport.

## Tests

- New: `tests/test_mcp_tls_default.py` (6 cases) -- helper block resolution across env values plus propagation through `_verify_payment`.
- Existing helper / payment suites: 26 passed (test_mcp_payment_helpers, test_config, test_manual_mode_fail_closed, test_mcp_payment_replay).

## Notes

- Non-breaking for callers that explicitly set `OPENCLAW_INSECURE_SKIP_TLS_VERIFY=1`.
- The pre-existing `test_middleware_config` failures (Windows file-handle `PermissionError`) are unrelated to this change.
